### PR TITLE
fix file name conflict on windows

### DIFF
--- a/lib/src/directory_name.dart
+++ b/lib/src/directory_name.dart
@@ -23,6 +23,14 @@ extension DirectoryName on Directory {
   }
 
   String _name(String name, String format, bool space) {
+    if (Platform.isWindows) {
+      return _forWindows(name, format, space);
+    } else {
+      return _forOthers(name, format, space);
+    }
+  }
+
+  String _forOthers(String name, String format, bool space) {
     // get all from directory path
     var list = Directory(path).listSync();
 
@@ -34,6 +42,24 @@ extension DirectoryName on Directory {
 
     int i = 0;
     while (nameList.contains(result)) {
+      i += 1;
+      result = name + (space ? ' ' : '') + format.replaceAll('d', '$i');
+    }
+    return result;
+  }
+
+  String _forWindows(String name, String format, bool space) {
+    // get all from directory path
+    var list = Directory(path).listSync();
+
+    // make name list and it is case-insensitive for windows file systems
+    var nameList = list.map((e) => e.absolute.path.split(separator).last.toLowerCase()).toList();
+
+    // make val for loop
+    var result = name;
+
+    int i = 0;
+    while (nameList.contains(result.toLowerCase())) {
       i += 1;
       result = name + (space ? ' ' : '') + format.replaceAll('d', '$i');
     }

--- a/lib/src/file_name.dart
+++ b/lib/src/file_name.dart
@@ -15,6 +15,14 @@ extension FileName on File {
   }
 
   String _name(String name, String format, bool space) {
+    if (Platform.isWindows) {
+      return _forWindows(name, format, space);
+    } else {
+      return _forOthers(name, format, space);
+    }
+  }
+
+  String _forOthers(String name, String format, bool space) {
     // get all from directory path
     var list = Directory(path).listSync();
 
@@ -32,6 +40,34 @@ extension FileName on File {
 
     int i = 0;
     while (nameList.contains(result)) {
+      i += 1;
+      result = fileName +
+          (space ? ' ' : '') +
+          format.replaceAll('d', '$i') +
+          fileType;
+    }
+    return result;
+  }
+
+  String _forWindows(String name, String format, bool space) {
+    // get all from directory path
+    var list = Directory(path).listSync();
+
+    // make name list and it is case-insensitive for windows file systems
+    // so nameList shoud be compared by lower-case
+    var nameList = list.map((e) => e.absolute.path.split(separator).last.toLowerCase()).toList();
+
+    // get file name
+    var fileName = name.substring(0, name.lastIndexOf('.'));
+
+    // get file type
+    var fileType = name.substring(name.lastIndexOf('.'), name.length);
+
+    // make val for loop
+    var result = name;
+
+    int i = 0;
+    while (nameList.contains(result.toLowerCase())) {
       i += 1;
       result = fileName +
           (space ? ' ' : '') +


### PR DESCRIPTION
I propose this patch for Windows.

I found `namePlus` conflicts file name on Windows system because its file name is `case-insensitive`.

patch will work on it;

before
`xxx/yyy.zzz`, `xxx/yyy(1).ZZZ`, `xxx/YYY(2).zzz` 
=> `xxx/yyy(1).zzz` conflicts with `xxx/yyy(1).ZZZ`

after
`xxx/yyy.zzz`, `xxx/yyy(1).ZZZ`, `xxx/YYY(2).zzz` 
=> `xxx/yyy(3).zzz` 

